### PR TITLE
Problem where linux version came before android

### DIFF
--- a/source/bindbc/sdl/dynload.d
+++ b/source/bindbc/sdl/dynload.d
@@ -695,13 +695,14 @@ SDLSupport loadSDL(const(char)* libName)
         lib.bindSymbol(cast(void**)&SDL_GetDisplayOrientation, "SDL_GetDisplayOrientation");
         lib.bindSymbol(cast(void**)&SDL_CreateThreadWithStackSize, "SDL_CreateThreadWithStackSize");
 
-        version(linux) {
-            lib.bindSymbol(cast(void**)&SDL_LinuxSetThreadPriority, "SDL_LinuxSetThreadPriority");
-        }
-        else version(Android) {
+        version(Android) 
+        {
             lib.bindSymbol(cast(void**)&SDL_IsChromebook, "SDL_IsChromebook");
             lib.bindSymbol(cast(void**)&SDL_IsDeXMode, "SDL_IsDeXMode");
             lib.bindSymbol(cast(void**)&SDL_AndroidBackButton, "SDL_AndroidBackButton");
+        }
+        else version(linux) {
+            lib.bindSymbol(cast(void**)&SDL_LinuxSetThreadPriority, "SDL_LinuxSetThreadPriority");
         }
 
         if(errorCount() != errCount) return SDLSupport.badLibrary;


### PR DESCRIPTION
This is a simple problem resolved by only change the veresion order, which Android should appear before version, as Android is either Android and Linux