### PR TITLE
version guards to avoid using stdc for WebAssembly

### DIFF
--- a/source/bindbc/sdl/bind/sdllog.d
+++ b/source/bindbc/sdl/bind/sdllog.d
@@ -6,7 +6,11 @@
 
 module bindbc.sdl.bind.sdllog;
 
-import core.stdc.stdarg : va_list;
+version(WebAssembly){}
+else{
+    import core.stdc.stdarg : va_list;
+}
+
 import bindbc.sdl.config;
 
 enum SDL_MAX_LOG_MESSAGE = 4096;
@@ -64,7 +68,8 @@ static if(staticBinding) {
         void SDL_LogError(int,const(char)*,...);
         void SDL_LogCritical(int,const(char)*,...);
         void SDL_LogMessage(int,SDL_LogPriority,const(char)*,...);
-        void SDL_LogMessageV(int,SDL_LogPriority,const(char)*,va_list);
+        version(WebAssembly){}
+        else{void SDL_LogMessageV(int,SDL_LogPriority,const(char)*,va_list);}
         void SDL_LogGetOutputFunction(SDL_LogOutputFunction,void**);
         void SDL_LogSetOutputFunction(SDL_LogOutputFunction,void*);
     }

--- a/source/bindbc/sdl/bind/sdlrwops.d
+++ b/source/bindbc/sdl/bind/sdlrwops.d
@@ -6,7 +6,9 @@
 
 module bindbc.sdl.bind.sdlrwops;
 
-import core.stdc.stdio : FILE;
+version(WebAssembly){}
+else{import core.stdc.stdio : FILE;}
+
 import bindbc.sdl.config;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
 
@@ -46,11 +48,14 @@ struct SDL_RWops {
             Windowsio windowsio;
         }
 
-        struct Stdio {
-            int autoclose;
-            FILE* fp;
+        version(WebAssembly){}
+        else{
+            struct Stdio {
+                int autoclose;
+                FILE* fp;
+            }
+            Stdio stdio;
         }
-        Stdio stdio;
 
         struct Mem {
             ubyte* base;
@@ -96,7 +101,7 @@ static if(sdlSupport >= SDLSupport.sdl206) {
 static if(staticBinding)  {
     extern(C) @nogc nothrow {
         SDL_RWops* SDL_RWFromFile(const(char)*,const(char)*);
-        SDL_RWops* SDL_RWFromFP(FILE*,SDL_bool);
+        version(WebAssembly){} else {SDL_RWops* SDL_RWFromFP(FILE*,SDL_bool);}
         SDL_RWops* SDL_RWFromMem(void*,int);
         SDL_RWops* SDL_RWFromConstMem(const(void)*,int);
         SDL_RWops* SDL_AllocRW();

--- a/source/bindbc/sdl/bind/sdlsyswm.d
+++ b/source/bindbc/sdl/bind/sdlsyswm.d
@@ -6,7 +6,12 @@
 
 module bindbc.sdl.bind.sdlsyswm;
 
-import core.stdc.config : c_long;
+version(WebAssembly){
+    alias c_ulong = ulong;
+}else{
+    import core.stdc.config : c_ulong;
+}
+
 import bindbc.sdl.config;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
 import bindbc.sdl.bind.sdlversion : SDL_version;

--- a/source/bindbc/sdl/bind/sdlthread.d
+++ b/source/bindbc/sdl/bind/sdlthread.d
@@ -6,7 +6,12 @@
 
 module bindbc.sdl.bind.sdlthread;
 
-import core.stdc.config : c_ulong;
+version(WebAssembly){
+    alias c_ulong = ulong;
+}else{
+    import core.stdc.config : c_ulong;
+}
+
 import bindbc.sdl.config;
 
 struct SDL_Thread;

--- a/source/bindbc/sdl/ttf.d
+++ b/source/bindbc/sdl/ttf.d
@@ -9,7 +9,12 @@ module bindbc.sdl.ttf;
 import bindbc.sdl.config;
 static if(bindSDLTTF):
 
-import core.stdc.config;
+version(WebAssembly){
+    alias c_long = long;
+}else{
+    import core.stdc.config : c_long;
+}
+
 import bindbc.sdl.bind.sdlerror : SDL_GetError, SDL_SetError;
 import bindbc.sdl.bind.sdlpixels : SDL_Color;
 import bindbc.sdl.bind.sdlrwops : SDL_RWops;


### PR DESCRIPTION
Dear Mike,

I have been struggling to compile an example code on https://theartofmachinery.com/2018/12/20/emscripten_d.html. I realized that bindbc-sdl uses some types from core.stdc. Those are not available when compiling for wasm. I could compile the example code with these modifications. You can merge and do some final touches if you want.

Thanks.
Ferhat