### PR TITLE
Fixing a broken lib.bindSymbol on android

### DIFF
--- a/source/bindbc/sdl/bind/sdlsystem.d
+++ b/source/bindbc/sdl/bind/sdlsystem.d
@@ -31,7 +31,7 @@ static if(staticBinding) {
             void* SDL_AndroidGetJNIEnv();
             void* SDL_AndroidGetActivity();
             const(char)* SDL_AndroidGetInternalStoragePath();
-            int SDL_AndroidGetInternalStorageState();
+            int SDL_AndroidGetExternalStorageState();
             const(char)* SDL_AndroidGetExternalStoragePath();
 
             static if(sdlSupport >= SDLSupport.sdl208) {
@@ -74,7 +74,7 @@ else {
             alias pSDL_AndroidGetJNIEnv = void* function();
             alias pSDL_AndroidGetActivity = void* function();
             alias pSDL_AndroidGetInternalStoragePath = const(char)* function();
-            alias pSDL_AndroidGetInternalStorageState = int function();
+            alias pSDL_AndroidGetExternalStorageState = int function();
             alias pSDL_AndroidGetExternalStoragePath = const(char)* function();
         }
 
@@ -83,7 +83,7 @@ else {
             pSDL_AndroidGetActivity SDL_AndroidGetActivity;
 
             pSDL_AndroidGetInternalStoragePath SDL_AndroidGetInternalStoragePath;
-            pSDL_AndroidGetInternalStorageState SDL_AndroidGetInternalStorageState;
+            pSDL_AndroidGetExternalStorageState SDL_AndroidGetExternalStorageState;
             pSDL_AndroidGetExternalStoragePath SDL_AndroidGetExternalStoragePath;
         }
         static if(sdlSupport >= SDLSupport.sdl208) {

--- a/source/bindbc/sdl/dynload.d
+++ b/source/bindbc/sdl/dynload.d
@@ -430,10 +430,10 @@ SDLSupport loadSDL(const(char)* libName)
         lib.bindSymbol(cast(void**)&SDL_AndroidGetActivity, "SDL_AndroidGetActivity");
 
         lib.bindSymbol(cast(void**)&SDL_AndroidGetInternalStoragePath, "SDL_AndroidGetInternalStoragePath");
-        lib.bindSymbol(cast(void**)&SDL_AndroidGetInternalStorageState, "SDL_AndroidGetInternalStorageState");
-        lib.bindSymbol(cast(void**)&SDL_AndroidGetExternalStoragePath, "SDL_AndroidGetExternalStoragePath");
-    }
 
+        lib.bindSymbol(cast(void**)&SDL_AndroidGetExternalStoragePath, "SDL_AndroidGetExternalStoragePath");
+        lib.bindSymbol(cast(void**)&SDL_AndroidGetExternalStorageState, "SDL_AndroidGetExternalStorageState");
+    }
     lib.bindSymbol(cast(void**)&SDL_GetWindowWMInfo, "SDL_GetWindowWMInfo");
     lib.bindSymbol(cast(void**)&SDL_CreateThread, "SDL_CreateThread");
     lib.bindSymbol(cast(void**)&SDL_GetThreadName, "SDL_GetThreadName");


### PR DESCRIPTION
In the android binding the function SDL_AndroidGetInternalStorageState was requested, but internal storage has not state (always connected), the function is called SDL_AndroidGetExternalStorageState