### PR TITLE
Fix DL_TOUCH_MOUSEID typo

### DIFF
--- a/source/bindbc/sdl/bind/sdltouch.d
+++ b/source/bindbc/sdl/bind/sdltouch.d
@@ -18,7 +18,7 @@ struct SDL_Finger {
     float pressure;
 }
 
-enum DL_TOUCH_MOUSEID = cast(uint)-1;
+enum SDL_TOUCH_MOUSEID = cast(uint)-1;
 
 static if(sdlSupport >= SDLSupport.sdl2010) {
     enum SDL_TouchDeviceType {


### PR DESCRIPTION
The `SDL_TOUCH_MOUSEID` enum is mistyped as `DL_TOUCH_MOUSEID`