### PR TITLE
change SDL_KeyCode back to int instead of uint

### DIFF
--- a/source/sdl/keycode.d
+++ b/source/sdl/keycode.d
@@ -21,7 +21,7 @@ deprecated("Please use the non-template variant instead"){
 	enum SDL_SCANCODE_TO_KEYCODE(SDL_Scancode x) = x | SDLK_SCANCODE_MASK;
 }
 
-alias SDL_KeyCode = uint;
+alias SDL_KeyCode = int;
 enum: SDL_KeyCode{
 	SDLK_UNKNOWN = 0,
 	SDLK_RETURN = '\r',


### PR DESCRIPTION
the original source defines SDL_KeyCode as a signed 32-bit integer:  https://github.com/libsdl-org/SDL/blob/SDL2/include/SDL_keycode.h#L45

the modification of SDL_KeyCode to uint broke the api. this commit reverts that change.