### PR TITLE
Modified for compilation compatibility with GNU GDC compiler

### DIFF
--- a/source/sdl/haptic.d
+++ b/source/sdl/haptic.d
@@ -10,7 +10,7 @@ module sdl.haptic;
 import bindbc.sdl.config;
 import bindbc.sdl.codegen;
 
-import sdl.joystick: SDL_Joystick;
+import sdl.joystick;
 
 struct SDL_Haptic;
 

--- a/source/sdl/keyboard.d
+++ b/source/sdl/keyboard.d
@@ -14,7 +14,7 @@ import sdl.keycode: SDL_KeyCode, SDL_Keymod;
 import sdl.rect: SDL_Rect;
 import sdl.scancode: SDL_Scancode;
 import sdl.stdinc: SDL_bool;
-import sdl.video: SDL_Window;
+import sdl.video;
 
 struct SDL_Keysym{
 	SDL_Scancode scancode;

--- a/source/sdl/messagebox.d
+++ b/source/sdl/messagebox.d
@@ -10,7 +10,7 @@ module sdl.messagebox;
 import bindbc.sdl.config;
 import bindbc.sdl.codegen;
 
-import sdl.video: SDL_Window;
+import sdl.video;
 
 alias SDL_MessageBoxFlags = uint;
 enum: SDL_MessageBoxFlags{

--- a/source/sdl/metal.d
+++ b/source/sdl/metal.d
@@ -9,7 +9,7 @@ module sdl.metal;
 import bindbc.sdl.config;
 import bindbc.sdl.codegen;
 
-import sdl.video: SDL_Window;
+import sdl.video;
 
 alias SDL_MetalView = void*;
 

--- a/source/sdl/mouse.d
+++ b/source/sdl/mouse.d
@@ -12,7 +12,7 @@ import bindbc.sdl.codegen;
 
 import sdl.stdinc: SDL_bool;
 import sdl.surface: SDL_Surface;
-import sdl.video: SDL_Window;
+import sdl.video;
 
 struct SDL_Cursor;
 

--- a/source/sdl/render.d
+++ b/source/sdl/render.d
@@ -14,7 +14,7 @@ import sdl.blendmode: SDL_BlendMode;
 import sdl.rect;
 import sdl.stdinc: SDL_bool;
 import sdl.surface: SDL_Surface;
-import sdl.video: SDL_Window;
+import sdl.video;
 import sdl.pixels: SDL_Color;
 
 alias SDL_RendererFlags = uint;

--- a/source/sdl/shape.d
+++ b/source/sdl/shape.d
@@ -13,7 +13,7 @@ import bindbc.sdl.codegen;
 import sdl.pixels: SDL_Color;
 import sdl.stdinc: SDL_bool;
 import sdl.surface: SDL_Surface;
-import sdl.video: SDL_Window, SDL_WindowFlags;
+import sdl.video;
 
 enum{
 	SDL_NONSHAPEABLE_WINDOW     = -1,

--- a/source/sdl/system.d
+++ b/source/sdl/system.d
@@ -10,9 +10,9 @@ module sdl.system;
 import bindbc.sdl.config;
 import bindbc.sdl.codegen;
 
-import sdl.render: SDL_Renderer;
+import sdl.render;
 import sdl.stdinc: SDL_bool;
-import sdl.video: SDL_Window;
+import sdl.video;
 
 version(Windows) version = Win32_GDK;
 version(WinGDK)  version = Win32_GDK;

--- a/source/sdl/syswm.d
+++ b/source/sdl/syswm.d
@@ -11,7 +11,7 @@ import bindbc.sdl.config;
 import bindbc.sdl.codegen;
 
 import sdl.stdinc: SDL_bool;
-import sdl.video: SDL_Window;
+import sdl.video;
 
 version(Windows){
 	import core.sys.windows.windef: HWND, UINT, WPARAM, LPARAM, HDC, HINSTANCE;

--- a/source/sdl/vulkan.d
+++ b/source/sdl/vulkan.d
@@ -11,7 +11,7 @@ import bindbc.sdl.config;
 import bindbc.sdl.codegen;
 
 import sdl.stdinc: SDL_bool;
-import sdl.video: SDL_Window;
+import sdl.video;
 
 mixin(joinFnBinds((){
 	FnBind[] ret;


### PR DESCRIPTION
This change does not modify logic, but rather avoid using few entries of single class imports like:
```
import sdl.video: SDL_Window
```
while generous import works fine
```
import sdl.video
```

Sample GDC compiler output:
```
source/sdl/haptic.d:13:8: internal compiler error: in make_import, at d/imports.cc:48
   13 | import sdl.joystick: SDL_Joystick;
      |        ^
0x72e5eb62814f __libc_start_call_main
	../sysdeps/nptl/libc_start_call_main.h:58
0x72e5eb628208 __libc_start_main_impl
	../csu/libc-start.c:360
```