### PR TITLE
add support for sdl2_image 2.8.x

### DIFF
--- a/source/bindbc/sdl/config.d
+++ b/source/bindbc/sdl/config.d
@@ -107,6 +107,7 @@ enum bindSDLImage = (){
 	else version(SDL_Image_204) return true;
 	else version(SDL_Image_205) return true;
 	else version(SDL_Image_2_6) return true;
+	else version(SDL_Image_2_8) return true;
 	else return false;
 }();
 


### PR DESCRIPTION
Commit for issue #64 
- Add sdl2 image version 2.8 to `config.d`