### PR TITLE
Fix dead code warning from config.d

### DIFF
--- a/source/bindbc/sdl/config.d
+++ b/source/bindbc/sdl/config.d
@@ -76,7 +76,7 @@ enum staticBinding = (){
 
 enum sdlSupport = (){
 	version(SDL_2_30)      return SDLSupport.v2_30;
-	version(SDL_2_28)      return SDLSupport.v2_28;
+	else version(SDL_2_28) return SDLSupport.v2_28;
 	else version(SDL_2_26) return SDLSupport.v2_26;
 	else version(SDL_2_24) return SDLSupport.v2_24;
 	else version(SDL_2022) return SDLSupport.v2_0_22;


### PR DESCRIPTION
missing else results in dead code warning which renders the library unusable with explicit versions through dub. else is added.