### PR TITLE
Support for constness

### DIFF
--- a/source/bindbc/sdl/config.d
+++ b/source/bindbc/sdl/config.d
@@ -14,7 +14,7 @@ struct SDL_version{
 	ubyte minor;
 	ubyte patch;
 	
-	int opCmp(SDL_version x) nothrow @nogc pure{
+	int opCmp(SDL_version x) nothrow @nogc pure const {
 		if(major != x.major)
 			return major - x.major;
 		else if(minor != x.minor)


### PR DESCRIPTION
Currently you can not do:
```D
const ret = loadSDLTTF();
if(ret < sdlTTFSupport)
    ...
```
ret should be mutable to avoid
```
Error: mutable method `bindbc.sdl.config.SDL_version.opCmp` is not callable using a `const` object
```